### PR TITLE
Revert "Bump python from 3.10.12-slim-bullseye to 3.12.0-slim-bullseye in /data-panel-api"

### DIFF
--- a/data-panel-api/Dockerfile
+++ b/data-panel-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.0-slim-bullseye
+FROM python:3.10.12-slim-bullseye
 COPY . /app
 WORKDIR /app
 RUN mkdir creds


### PR DESCRIPTION
Reverts kikeelectronico/la-fabrica-services#196