### PR TITLE
migrate hue-2-mqtt to see

### DIFF
--- a/hue-2-mqtt/requirements.txt
+++ b/hue-2-mqtt/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.31.0
 paho-mqtt==1.6.1
 python-dotenv==1.0.0
+sseclient-py==1.8.0


### PR DESCRIPTION
- change switch
- turn off some lights when not at home
- turn on some lights when get home
- target branch
- update dev test and build
- tabs
- change workflow name
- test the workflow
- add new device
- add support for presence detection
- add presence detection
- add support for get resource at clip v2 api
- add occupancy control
- getting homeware id for every device
- rename services variables
- add contact sensor and battery level
- do not set presence state
- add connectivity control
- decrease frequency
- enable motion detection in bedroom
- add support to sse
- remove ssl warnings
- add mirror dimmer
- remove long release event
- delete long press and json import
- reconnect if an unexpected disconnection happens
- preload buttons short press data
- rename variable
- preload dimmers data
- preload to cache only the needed data
- move global declaration
- disable heating if window is open
- process all events presents in the message
- migrate to sse
