### PR TITLE
lights

### DIFF
--- a/logic-pool-hue/sensors.py
+++ b/logic-pool-hue/sensors.py
@@ -22,16 +22,16 @@ def bathroom(service, homeware, mqtt_client):
   if service["id"] == "73ef0d76-de9f-4cd1-b460-ec626fbc70fc":
     state = service["motion"]["motion"]
     if state:
-      mqtt_client.publish("tasks", json.dumps({"id": "bedroom_hue_sensor_2", "action": "delete"}))
-      mqtt_client.publish("tasks", json.dumps({"id": "bedroom_light001", "action": "delete"}))
+      mqtt_client.publish("tasks", json.dumps({"id": "bathroom_light001", "action": "delete"}))
+      mqtt_client.publish("tasks", json.dumps({"id": "bathroom_hue_sensor_2", "action": "delete"}))
       if homeware.get("scene_dim","enable"):
         homeware.execute("hue_sensor_2","on",True)
       else:
         homeware.execute("light001","on",True)
     else:
         if not homeware.get("hue_sensor_14", "on"):
-          mqtt_client.publish("tasks", json.dumps({"id": "bedroom_hue_sensor_2", "action": "set", "delta": 2, "device_id": "hue_sensor_2", "param": "on", "value": False}))
-          mqtt_client.publish("tasks", json.dumps({"id": "bedroom_light001", "action": "set", "delta": 2, "device_id": "light001", "param": "on", "value": False}))
+          mqtt_client.publish("tasks", json.dumps({"id": "bathroom_hue_sensor_2", "action": "set", "delta": 2, "device_id": "hue_sensor_2", "param": "on", "value": False}))
+          mqtt_client.publish("tasks", json.dumps({"id": "bathroom_light001", "action": "set", "delta": 2, "device_id": "light001", "param": "on", "value": False}))
 
 def hall(service, homeware):
   if service["id"] == "918cdad4-9c5e-40f7-9ef2-e6a64072a2ae":

--- a/logic-pool-mqtt/general.py
+++ b/logic-pool-mqtt/general.py
@@ -33,8 +33,9 @@ def atHome(homeware, topic, payload):
       homeware.execute("thermostat_livingroom", "thermostatMode", "heat")
       homeware.execute("hue_4", "on", True)
       homeware.execute("hue_5", "on", True)
-      # homeware.execute("hue_8", "on", True)
       homeware.execute("hue_11", "on", True)
+      homeware.execute("rgb001", "on", True)
+      homeware.execute("rgb002", "on", True)
       homeware.execute("switch_prepare_home", "on", False)
     else:
       homeware.execute("thermostat_dormitorio", "thermostatMode", "off")
@@ -45,12 +46,13 @@ def atHome(homeware, topic, payload):
       homeware.execute("light004", "on", False)
       homeware.execute("hue_1", "on", False)
       homeware.execute("light003", "on", False)
-      # homeware.execute("hue_8", "on", False)
       homeware.execute("hue_9", "on", False)
       homeware.execute("hue_10", "on", False)
       homeware.execute("hue_11", "on", False)
       homeware.execute("hue_4", "on", False)
       homeware.execute("hue_5", "on", False)
+      homeware.execute("rgb001", "on", False)
+      homeware.execute("rgb002", "on", False)
       
 # Prepare the home for arrival
 def prepareHome(homeware, topic, payload):


### PR DESCRIPTION
- change switch
- turn off some lights when not at home
- turn on some lights when get home
- Bump python in /logic-pool-mqtt
- Bump react-bootstrap from 2.9.0 to 2.9.1 in /data-panel-front
- Bump python in /logic-pool-time
- Bump google-cloud-speech from 2.21.0 to 2.21.1 in /voice-alert
- Bump python in /data-panel-api
- Bump fastapi from 0.103.2 to 0.104.1 in /data-panel-api
- Bump google-api-python-client from 2.103.0 to 2.105.0 in /telegram-bot
- target branch
- Revert "Bump python from 3.10.12-slim-bullseye to 3.12.0-slim-bullseye in /data-panel-api"
- update dev test and build
- Revert "Bump python from 3.10.12-slim-bullseye to 3.12.0-slim-bullseye in /logic-pool-time"
- tabs
- Revert "Bump python from 3.10.12-slim-bullseye to 3.12.0-slim-bullseye in /logic-pool-mqtt"
- change workflow name
- test the workflow
- add new device
- add support for presence detection
- add presence detection
- add support for get resource at clip v2 api
- add occupancy control
- getting homeware id for every device
- rename services variables
- add contact sensor and battery level
- do not set presence state
- add connectivity control
- decrease frequency
- enable motion detection in bedroom
- add support to sse
- remove ssl warnings
- add mirror dimmer
- remove long release event
- delete long press and json import
- reconnect if an unexpected disconnection happens
- preload buttons short press data
- rename variable
- preload dimmers data
- preload to cache only the needed data
- move global declaration
- disable heating if window is open
- process all events presents in the message
- migrate to sse
- force a reconnect because i can't find the bug
- force reconnect
- Bump uvicorn from 0.23.2 to 0.24.0.post1 in /data-panel-api
- Bump python in /logic-pool-time
- Bump react-router-dom from 6.17.0 to 6.18.0 in /data-panel-front
- Bump google-api-python-client from 2.105.0 to 2.106.0 in /telegram-bot
- Bump google-cloud-storage from 2.12.0 to 2.13.0 in /telegram-bot
- Bump python in /logic-pool-mqtt
- Bump google-cloud-speech from 2.21.1 to 2.22.0 in /voice-alert
- Bump python in /data-panel-api
- Bump google-cloud-bigquery from 3.12.0 to 3.13.0 in /mqtt-2-bigquery
- add hall and bathroom sensors
- add hall and bathroom motion sensors
- maybe that should be a True
- include sunset time block
- create sunset key
- move dependabot to dev branch
- Revert "Bump python from 3.10.12-slim-bullseye to 3.12.0-slim-bullseye in /data-panel-api"
- Revert "Bump python from 3.10.12-slim-bullseye to 3.12.0-slim-bullseye in /logic-pool-mqtt"
- Revert "Bump python from 3.10.12-slim-bullseye to 3.12.0-slim-bullseye in /logic-pool-time"
- Bump openai from 0.28.1 to 1.1.1 in /logic-pool-time
- Bump keras from 2.14.0 to 2.15.0 in /data-panel-api
- Bump google-api-python-client from 2.106.0 to 2.107.0 in /telegram-bot
- Bump openai from 0.28.1 to 1.1.1 in /logic-pool-mqtt
- Revert "Bump keras from 2.14.0 to 2.15.0 in /data-panel-api"
- dev test on pull request
- disable motion sensor on scene activated
- reverse logic
- Change sunrise hour
- run motion logic on dim scene change
- get astro data
- remove telegram message
- add task scheduler
- add task-scheduler to production builds
- add task-scheduler to docker-compose
- add delete capabilities
- schedule a task for turning off bedroom lights
- remove old lines
- optimize the code
- change delta to seconds
- update delta time
- move delete actions
- delete both always
- schedule turn off task for bathroom
- Update sensors.py
- change ids
- Update main.py
- Bump keras from 2.14.0 to 2.15.0 in /data-panel-api
- Bump openai from 1.1.1 to 1.2.3 in /logic-pool-time
- Bump openai from 1.1.1 to 1.2.3 in /logic-pool-mqtt
- Bump @testing-library/react from 14.0.0 to 14.1.0 in /data-panel-front
- Actualizar requirements.txt
- refactor hood control and include window sensor
- comment voice alerts
- Bump @testing-library/react from 14.1.0 to 14.1.2 in /data-panel-front
- Bump google-api-python-client from 2.107.0 to 2.108.0 in /telegram-bot
- Bump tensorflow from 2.14.0 to 2.15.0 in /data-panel-api
- case sensor_id = None
- change comment
- create astroday scene
- add new abnormal tempetarue alert
- rename function
- rename function
- Bump openai from 1.2.3 to 1.3.5 in /logic-pool-mqtt
- Bump react-router-dom from 6.18.0 to 6.20.0 in /data-panel-front
- Bump pychromecast from 13.0.7 to 13.0.8 in /data-panel-autoload
- Bump openai from 1.2.3 to 1.3.5 in /logic-pool-time
- Bump @adobe/css-tools from 4.3.1 to 4.3.2 in /data-panel-front
- remove rgb propagation
- Revert "Bump tensorflow from 2.14.0 to 2.15.0 in /data-panel-api"
- Bump keras from 2.14.0 to 3.0.0 in /data-panel-api
- Revert "Bump keras from 2.14.0 to 3.0.0 in /data-panel-api"
- Bump react-router-dom from 6.20.0 to 6.20.1 in /data-panel-front
- Bump @testing-library/jest-dom from 6.1.4 to 6.1.5 in /data-panel-front
- Bump openai from 1.3.5 to 1.3.7 in /logic-pool-time
- Bump openai from 1.3.5 to 1.3.7 in /logic-pool-mqtt
- reset edison bulb if changed
- use GITHUB_TOKEN
- reorder for build test
- update secret
- build test
- update secret
- update secret
- test token
- test token
- test
- permissions
- remove permissions
- update temps
- change logic for dimmer scene lights
- use the hue sensor for switching
- add task-scheduler to dependabot analysis
- issue a voice alert when the window has been closed
- get light sensors data
- consider light sensor when switching lights
- Bump google-api-python-client from 2.108.0 to 2.110.0 in /telegram-bot
- Bump openai from 1.1.1 to 1.3.7 in /task-scheduler
- Bump google-cloud-speech from 2.22.0 to 2.23.0 in /voice-alert
- Bump python in /task-scheduler
- run concurrently in dev
- update bedroom temps
- Bump google-cloud-texttospeech from 2.14.2 to 2.15.0 in /voice-alert
- log sensor
- add hue_8 and hue_11 to at home routine
- add humidity alerts
- increment timer
- delete alerts
- add prepare home for arrival button
- add hue-sensors-alerts
- add not
- no_contact
- alert only on week days
- Bump fastapi from 0.104.1 to 0.109.1 in /data-panel-api
- add hue_8 as radiator
- disable hue_8 as light
- remove hue_8 as ac unit
- change high humidity alert value
- include new lights into athome logic
- change tasks ids
